### PR TITLE
Improve test coverage for patch and get bulk

### DIFF
--- a/src/Sae.php
+++ b/src/Sae.php
@@ -147,8 +147,9 @@ class Sae {
 
     $new = json_encode($patched);
 
-    if (!$this->validate($new)) {
-      return FALSE;
+    $validation_info = $this->validate($new);
+    if (!$validation_info['valid']) {
+      throw new \Exception(json_encode((object) $validation_info));
     }
 
     return $this->storage->store($new, "{$id}");

--- a/src/Sae.php
+++ b/src/Sae.php
@@ -60,10 +60,13 @@ class Sae {
     if (isset($id)) {
       return $this->storage->retrieve($id);
     }
-    else {
-      if ($this->storage instanceof BulkRetriever) {
+    elseif ($this->storage instanceof BulkRetriever) {
         return $this->storage->retrieveAll();
-      }
+    }
+    else {
+      throw new \Exception(
+        'Neither data for the id, nor storage supporting bulk retrieval found.'
+      );
     }
   }
 

--- a/tests/SaeTest.php
+++ b/tests/SaeTest.php
@@ -182,6 +182,17 @@ class SaeTest extends \PHPUnit\Framework\TestCase
     );
   }
 
+  public function testCannotPatchResultingInInvalidData() {
+    // Remove price, a required property.
+    $json_patch = '{
+      "price": null
+    }';
+    $this->expectExceptionMessage('{"valid":false,"errors":[{"property":"price","pointer":"\/price","message":"The property price is required","constraint":"required","context":1}]}');
+    $this->engine->patch("1", $json_patch);
+    // Confirm that the PATCH target remained unchanged.
+    $this->assertEquals($this->defaultJson, $this->engine->get("1"));
+  }
+
   public function testCannotPatchMissingData() {
     $json_patch = '{
       "id": 2,

--- a/tests/SaeTest.php
+++ b/tests/SaeTest.php
@@ -101,6 +101,12 @@ class SaeTest extends \PHPUnit\Framework\TestCase
     }
   }
 
+  public function testCannotGetBulkFromUnsupportedStorage() {
+    $unsupported_storage_engine = new Sae\Sae(new UnsupportedMemory(), $this->jsonSchema);
+    $this->expectExceptionMessage('Neither data for the id, nor storage supporting bulk retrieval found.');
+    $data = $unsupported_storage_engine->get();
+  }
+
   public function testCanGetAnEmptySet() {
     // Remove item from setUp() before testing for empty set.
     $this->engine->delete("1");
@@ -189,8 +195,6 @@ class SaeTest extends \PHPUnit\Framework\TestCase
     }';
     $this->expectExceptionMessage('{"valid":false,"errors":[{"property":"price","pointer":"\/price","message":"The property price is required","constraint":"required","context":1}]}');
     $this->engine->patch("1", $json_patch);
-    // Confirm that the PATCH target remained unchanged.
-    $this->assertEquals($this->defaultJson, $this->engine->get("1"));
   }
 
   public function testCannotPatchMissingData() {
@@ -213,7 +217,7 @@ class SaeTest extends \PHPUnit\Framework\TestCase
   }
 }
 
-class Memory implements \Contracts\Storage, \Contracts\BulkRetriever {
+class UnsupportedMemory implements \Contracts\Storage {
   private $storage = [];
 
   public function retrieve(string $id): ?string
@@ -222,11 +226,6 @@ class Memory implements \Contracts\Storage, \Contracts\BulkRetriever {
       return $this->storage[$id];
     }
     return NULL;
-  }
-
-  public function retrieveAll(): array
-  {
-    return $this->storage;
   }
 
   public function store(string $data, string $id = NULL): string
@@ -247,6 +246,16 @@ class Memory implements \Contracts\Storage, \Contracts\BulkRetriever {
     }
     return FALSE;
   }
+}
+
+class Memory extends UnsupportedMemory implements \Contracts\BulkRetriever {
+
+  private $storage = [];
+
+  public function retrieveAll(): array {
+    return $this->storage;
+  }
+
 }
 
 class Sequential implements \Contracts\IdGenerator {


### PR DESCRIPTION
This PR adds two tests which should target the 2 missing branches pointed out by Code Climate.

For the patch changes to Sae, I corrected my handling of the validation.
For the get bulk on non-supported storage, I broke up the Memory class into a parent UnsupportedMemory, and a child inheriting all of that, plus implementing the bulk storage, leaving the rest of the test untouched. For the new test, I bypass the engine from SaeTest to use the unsupported engine, which triggers the exception.

